### PR TITLE
Add module Reader.Except

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "Punie/elm-reader",
     "summary": "Read configuration from an implicit environment",
     "license": "BSD-3-Clause",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "exposed-modules": [
         "Reader",
         "Reader.Except"

--- a/elm.json
+++ b/elm.json
@@ -5,7 +5,8 @@
     "license": "BSD-3-Clause",
     "version": "1.0.3",
     "exposed-modules": [
-        "Reader"
+        "Reader",
+        "Reader.Except"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/src/Reader/Except.elm
+++ b/src/Reader/Except.elm
@@ -1,0 +1,75 @@
+module Reader.Except
+    exposing
+        ( Except
+        , return
+        , fail
+        , map
+        , andMap
+        , andThen
+        , join
+        )
+
+import Reader exposing (Reader)
+import Result exposing (Result(..))
+
+
+type alias Except env err val =
+    Reader env (Result err val)
+
+
+return : a -> Except env err a
+return =
+    Reader.reader << Ok
+
+
+fail : err -> Except env err a
+fail =
+    Reader.reader << Err
+
+
+map : (a -> b) -> Except env err a -> Except env err b
+map =
+    Reader.map << Result.map
+
+
+andMap : Except env err a -> Except env err (a -> b) -> Except env err b
+andMap v f =
+    let
+        go k =
+            v |> Reader.andThen (unpack fail (return << k))
+    in
+        f |> Reader.andThen (unpack fail go)
+
+
+andThen : (a -> Except env err a) -> Except env err a -> Except env err a
+andThen f x =
+    x |> Reader.andThen (unpack fail f)
+
+
+join : Except env err (Except env err a) -> Except env err a
+join x =
+    x |> Reader.andThen (unpack fail identity)
+
+
+
+-- HELPERS
+
+
+unpack : (e -> b) -> (a -> b) -> Result e a -> b
+unpack ferr fval result =
+    case result of
+        Err err ->
+            ferr err
+
+        Ok val ->
+            fval val
+
+
+resultAndMap : Result e a -> Result e (a -> b) -> Result e b
+resultAndMap rx rf =
+    case ( rx, rf ) of
+        ( _, Err err ) ->
+            Err err
+
+        ( x, Ok f ) ->
+            Result.map f x

--- a/src/Reader/Except.elm
+++ b/src/Reader/Except.elm
@@ -1,7 +1,7 @@
 module Reader.Except
     exposing
         ( Except
-        , return
+        , succeed
         , fail
         , map
         , andMap
@@ -9,43 +9,81 @@ module Reader.Except
         , join
         )
 
+{-| Sometimes, you may want to build up a computation using `Reader env value` where
+the value is a result that may or may not fail. Elm already provides us with the
+`Result err value` that provides this functionality.
+However, working with nested ADT can be cumbersome. This module exposes the type
+`Except env err val` which is just a type alias for a `Reader env (Result err val)`
+and provides some useful functions for mapping over or chaining such nested computations.
+
+
+# The Except type
+
+@docs Except
+
+
+# Construction
+
+@docs succeed, fail
+
+
+# Transformations and chaining
+
+@docs map, andMap, andThen, join
+
+-}
+
 import Reader exposing (Reader)
 import Result exposing (Result(..))
 
 
+{-| The Except type wraps the result from a Reader into a Result.
+-}
 type alias Except env err val =
     Reader env (Result err val)
 
 
-return : a -> Except env err a
-return =
+{-| Embed a successful value inside a Reader.
+-}
+succeed : a -> Except env err a
+succeed =
     Reader.reader << Ok
 
 
+{-| Embeds a failure inside a Reader.
+-}
 fail : err -> Except env err a
 fail =
     Reader.reader << Err
 
 
+{-| Apply a function to the resulting value of the Reader if successful.
+-}
 map : (a -> b) -> Except env err a -> Except env err b
 map =
     Reader.map << Result.map
 
 
+{-| Apply a function embeded in an Except to a successful value in an Except.
+-}
 andMap : Except env err a -> Except env err (a -> b) -> Except env err b
 andMap v f =
     let
         go k =
-            v |> Reader.andThen (unpack fail (return << k))
+            v |> Reader.andThen (unpack fail (succeed << k))
     in
         f |> Reader.andThen (unpack fail go)
 
 
+{-| Chain Excepts together.
+-}
 andThen : (a -> Except env err a) -> Except env err a -> Except env err a
 andThen f x =
     x |> Reader.andThen (unpack fail f)
 
 
+{-| Discards one level of Except
+-}
 join : Except env err (Except env err a) -> Except env err a
 join x =
     x |> Reader.andThen (unpack fail identity)


### PR DESCRIPTION
The new module Reader.Except (based on the `ExceptT e m a` monad
transformer in Haskell specialised for the Reader monad), provides
some helpful functions to work with a Reader where the value expected
is of type `Result e a`, representing the possibility of failure.